### PR TITLE
allow compilation on stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ exclude = ["/.gitlab-ci.yml", ".gitignore", ".gitattributes", "/.github/*"]
 [dependencies]
 aarch64-cpu = { version = "9.3" }
 tock-registers = { version = "0.8.x", default-features = false }
+
+[features]
+default = ["nightly"]
+nightly = []

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -7,7 +7,8 @@ pub fn halt() {
 }
 
 #[cfg(feature = "nightly")]
-mod exceptions {
+#[allow(clippy::missing_safety_doc)]
+pub mod exceptions {
     use core::arch::asm;
 
     /// Generate an exception targeting EL1, with the specified exception code

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -6,6 +6,7 @@ pub fn halt() {
     unsafe { asm!("wfi", options(nomem, nostack)) }
 }
 
+#[cfg(feature = "nightly")]
 mod exceptions {
     use core::arch::asm;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 #![allow(dead_code)]
-#![feature(asm_const)]
+#![cfg_attr(feature = "nightly", feature(asm_const))]
 #![no_std]
 
 pub mod instructions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 #![allow(dead_code)]
-#![allow(stable_features)]
 #![feature(asm_const)]
 #![no_std]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 
 #![allow(dead_code)]
 #![allow(stable_features)]
-#![feature(asm_const, core_intrinsics)]
+#![feature(asm_const)]
 #![no_std]
 
 pub mod instructions;

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1,4 +1,3 @@
-use core::convert::{From, Into};
 use core::fmt;
 use core::ops;
 


### PR DESCRIPTION
My goal is to use the `VirtAddr` and `PhysAddr` in other crates which are stable. With this PR this should be possible:

```toml
[target.'cfg(target_arch = "aarch64")'.dependencies]
aarch64 = { path = "../../rust-aarch64" , default-features = false}
```

Not 100% sure if this is all correct, as it is difficult to test without an aarch64 machine.
